### PR TITLE
corrected the tab names on pages - customers, reports and settings

### DIFF
--- a/src/pages/Customers.jsx
+++ b/src/pages/Customers.jsx
@@ -4,7 +4,7 @@ import Layout from "../Components/Layout";
 const Customers = () => {
   return (
     <>
-      <Layout header="category">
+      <Layout header="customers">
         <div>customers</div>
       </Layout>
     </>

--- a/src/pages/Reports.jsx
+++ b/src/pages/Reports.jsx
@@ -2,7 +2,7 @@ import Layout from "../Components/Layout";
 
 const Reports = () => {
   return (
-    <Layout header="products">
+    <Layout header="reports">
       <div>Reports</div>
     </Layout>
   );

--- a/src/pages/Setting.jsx
+++ b/src/pages/Setting.jsx
@@ -2,7 +2,7 @@ import Layout from "../Components/Layout";
 
 const Setting = () => {
   return (
-    <Layout header="products">
+    <Layout header="settings">
       <div>settings</div>
     </Layout>
   );


### PR DESCRIPTION
Fix: #7 . The issue resolved under the JWOC

The sidebar contains six tabs in total currently. On clicking each of them the **title** is displayed on the main area. The title is same as the tab given. For example on clicking Dashboard from the sidebar displays the title and description as Dashboard but this was not the pattern for **customers, reports and settings**. Hence corrected the titles on the corresponding pages.

**Before :**

On clicking Customers-
![image](https://github.com/Swadeshit27/Admin-panel-frontend/assets/30958769/4791daf3-4fba-4897-9188-6bb984de8d9e)


On clicking Reports-
![image](https://github.com/Swadeshit27/Admin-panel-frontend/assets/30958769/4203bfe0-398d-4194-8b6a-e00fb22fc2d6)


On clicking Settings-
![image](https://github.com/Swadeshit27/Admin-panel-frontend/assets/30958769/6743f91b-9c8e-48a1-8e08-1b15cd87f8b4)


**After correcting the changes reflected:**
On clicking Customers-
![image](https://github.com/Swadeshit27/Admin-panel-frontend/assets/30958769/52e766f5-6b55-4dbf-a49b-3f30109b15b5)


On clicking Reports-
![image](https://github.com/Swadeshit27/Admin-panel-frontend/assets/30958769/d66151be-1b78-4e12-b0ba-c342a9fa8bb2)


On clicking Settings-
![image](https://github.com/Swadeshit27/Admin-panel-frontend/assets/30958769/03e93dcd-fe1c-4e02-a786-7b5107f091e5)

